### PR TITLE
Fix vCenter Reachability check

### DIFF
--- a/HXTool.py
+++ b/HXTool.py
@@ -827,11 +827,11 @@ def pre_upgrade_check(ip):
         else:
             try:
                 l = line.split(":")
-                if len(l) == 2:
-                    dnip = l[1]
-                    dnip = dnip.replace("https://", "")
+                if len(l) == 3:
+                    dnip = l[2]
+                    dnip = dnip.replace("//", "")
                     vcenterip = dnip.strip()
-                    msg = "\r\nvCenter IP Address: " + str(vcenterip) + "\r"
+                    msg = "\r\nvCenter FQDN: " + str(vcenterip) + "\r"
                     log_msg(INFO, msg)
             except Exception:
                 pass


### PR DESCRIPTION
Fix vCenter Reachability check if vCenter is registered with HyperFlex using FQDN.

Original script splits the FQDN string "vCenterURL: https://vc.subdomain.domain.tld" on ":" resulting in something like:

['    vCenterURL', ' https', '//vc.subdomain.domain.tld']

which is length 3, not 2, thus the if section is never processed. Then, since the https://vc.subdomain.domain.tld is already split to "https" and "//vc.subdomain.domain.tld", we need to remove only "//" instead of whole "https://".